### PR TITLE
feat: [GATE-24] 닉네임 중복체크 API 및 회원 상태 관리 추가

### DIFF
--- a/src/main/java/com/ureca/gate/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/ureca/gate/global/exception/errorcode/CommonErrorCode.java
@@ -22,7 +22,9 @@ public enum CommonErrorCode implements ErrorCode{
     JWT_AUTHORIZATION_FAILED(HttpStatus.UNAUTHORIZED,"4106","권한이 없습니다."),
 
     //user error (4001~
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"4001","해당 유저를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"4201","해당 유저를 찾을 수 없습니다."),
+    USER_DUPLICATE_NICKNAME(HttpStatus.CONFLICT,"4202", "중복된 닉네임이 존재합니다."),
+
     LOGOUT_MEMBER(HttpStatus.FORBIDDEN, "3001", "로그아웃된 사용자입니다.(재 로그인 하세요."),
 
     TEST_NOT_FOUND(HttpStatus.UNAUTHORIZED,"8888","테스트 아이디가 없습니다."),

--- a/src/main/java/com/ureca/gate/member/application/AuthenticationServiceImpl.java
+++ b/src/main/java/com/ureca/gate/member/application/AuthenticationServiceImpl.java
@@ -5,7 +5,7 @@ import com.ureca.gate.global.util.jwt.JwtUtil;
 import com.ureca.gate.member.application.outputport.KakaoOauthService;
 import com.ureca.gate.member.application.outputport.MemberRepository;
 import com.ureca.gate.member.controller.inputport.AuthenticationService;
-import com.ureca.gate.member.controller.response.UserSignInResponse;
+import com.ureca.gate.member.controller.response.MemberSignInResponse;
 import com.ureca.gate.member.domain.Member;
 import com.ureca.gate.member.domain.OauthInfo;
 import lombok.RequiredArgsConstructor;
@@ -24,15 +24,15 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     private static final String ROLE_USER = "ROLE_USER";
 
     @Transactional
-    public UserSignInResponse login(String code){
+    public MemberSignInResponse login(String code){
         String idToken = kakaoOauthService.getKakaoIdToken(code);
-        System.out.println(idToken);
         OauthInfo oauthInfo = kakaoOauthService.getOauthInfoByToken(idToken);
         Member member = memberRepository.findByOauthInfoOid(oauthInfo.getOid()).orElseGet(()-> memberRepository.forceJoin(oauthInfo));
 
-        return UserSignInResponse.from(
+        return MemberSignInResponse.from(
                 jwtUtil.createAccessToken(member.getId(), ROLE_USER),
-                getOrGenerateRefreshToken(member));
+                getOrGenerateRefreshToken(member),
+                member.getStatus());
     }
 
     @Transactional

--- a/src/main/java/com/ureca/gate/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/ureca/gate/member/application/MemberServiceImpl.java
@@ -1,0 +1,24 @@
+package com.ureca.gate.member.application;
+
+import com.ureca.gate.global.exception.custom.BusinessException;
+import com.ureca.gate.member.application.outputport.MemberRepository;
+import com.ureca.gate.member.controller.inputport.MemberService;
+import com.ureca.gate.member.controller.request.NicknameCheckRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.ureca.gate.global.exception.errorcode.CommonErrorCode.USER_DUPLICATE_NICKNAME;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public void checkNickname(NicknameCheckRequest nicknameCheckRequest){
+        if(memberRepository.existsByNickname(nicknameCheckRequest.getNickName())){
+            throw new BusinessException(USER_DUPLICATE_NICKNAME);
+        }
+    }
+
+}

--- a/src/main/java/com/ureca/gate/member/application/outputport/MemberRepository.java
+++ b/src/main/java/com/ureca/gate/member/application/outputport/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository {
 
     public Member forceJoin(OauthInfo oauthInfo);
 
+    public boolean existsByNickname(String nickName);
+
 }

--- a/src/main/java/com/ureca/gate/member/controller/MemberController.java
+++ b/src/main/java/com/ureca/gate/member/controller/MemberController.java
@@ -2,7 +2,9 @@ package com.ureca.gate.member.controller;
 
 import com.ureca.gate.global.dto.response.SuccessResponse;
 import com.ureca.gate.member.controller.inputport.AuthenticationService;
-import com.ureca.gate.member.controller.response.UserSignInResponse;
+import com.ureca.gate.member.controller.inputport.MemberService;
+import com.ureca.gate.member.controller.request.NicknameCheckRequest;
+import com.ureca.gate.member.controller.response.MemberSignInResponse;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -15,12 +17,19 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final AuthenticationService authenticationService;
+    private final MemberService memberService;
 
     @GetMapping("/kakao")
-    public SuccessResponse<UserSignInResponse> kakaoLogin(@RequestParam final String code) {
+    public SuccessResponse<MemberSignInResponse> kakaoLogin(@RequestParam final String code) {
         // Step 2: idToken으로 로그인 처리
-        UserSignInResponse response = authenticationService.login(code);
+        MemberSignInResponse response = authenticationService.login(code);
         return SuccessResponse.success(response);
+    }
+
+    @GetMapping("/check-nickname")
+    public SuccessResponse<String> checkNickname(@RequestBody NicknameCheckRequest nicknameCheckRequest){
+        memberService.checkNickname(nicknameCheckRequest);
+        return SuccessResponse.success("사용 가능한 닉네임입니다.");
     }
 
 }

--- a/src/main/java/com/ureca/gate/member/controller/inputport/AuthenticationService.java
+++ b/src/main/java/com/ureca/gate/member/controller/inputport/AuthenticationService.java
@@ -1,13 +1,13 @@
 package com.ureca.gate.member.controller.inputport;
 
 
-import com.ureca.gate.member.controller.response.UserSignInResponse;
+import com.ureca.gate.member.controller.response.MemberSignInResponse;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface AuthenticationService {
 
-    UserSignInResponse login(String code);  // 로그인 처리
+    MemberSignInResponse login(String code);  // 로그인 처리
 
 
 }

--- a/src/main/java/com/ureca/gate/member/controller/inputport/MemberService.java
+++ b/src/main/java/com/ureca/gate/member/controller/inputport/MemberService.java
@@ -1,0 +1,10 @@
+package com.ureca.gate.member.controller.inputport;
+
+import com.ureca.gate.member.controller.request.NicknameCheckRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface MemberService {
+
+    void checkNickname(NicknameCheckRequest nicknameCheckRequest);
+}

--- a/src/main/java/com/ureca/gate/member/controller/request/NicknameCheckRequest.java
+++ b/src/main/java/com/ureca/gate/member/controller/request/NicknameCheckRequest.java
@@ -1,0 +1,8 @@
+package com.ureca.gate.member.controller.request;
+
+import lombok.Getter;
+
+@Getter
+public class NicknameCheckRequest {
+    private String nickName;
+}

--- a/src/main/java/com/ureca/gate/member/controller/response/MemberSignInResponse.java
+++ b/src/main/java/com/ureca/gate/member/controller/response/MemberSignInResponse.java
@@ -1,19 +1,22 @@
 package com.ureca.gate.member.controller.response;
 
+import com.ureca.gate.member.domain.Enum.Status;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
-public class UserSignInResponse {
+public class MemberSignInResponse {
 
     private String accessToken;
     private String refreshToken;
+    private Status status;
 
-    public static UserSignInResponse from(String accessToken, String refreshToken){
-        return UserSignInResponse.builder()
+    public static MemberSignInResponse from(String accessToken, String refreshToken, Status status){
+        return MemberSignInResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .status(status)
                 .build();
         }
 }

--- a/src/main/java/com/ureca/gate/member/domain/Enum/Status.java
+++ b/src/main/java/com/ureca/gate/member/domain/Enum/Status.java
@@ -1,0 +1,5 @@
+package com.ureca.gate.member.domain.Enum;
+
+public enum Status {
+    ACTIVE,NONACTIVE
+}

--- a/src/main/java/com/ureca/gate/member/domain/Member.java
+++ b/src/main/java/com/ureca/gate/member/domain/Member.java
@@ -2,24 +2,35 @@ package com.ureca.gate.member.domain;
 
 import com.ureca.gate.member.domain.Enum.Gender;
 import com.ureca.gate.member.domain.Enum.Role;
+import com.ureca.gate.member.domain.Enum.Status;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 public class Member {
     private Long id;
+    private String nickName;
     private OauthInfo oauthInfo;
     private Integer age;
     private Gender gender;
     private Role role;
+    private Status status;
+    private LocalDateTime createAt;
+    private LocalDateTime updateAt;
 
     @Builder
-    public Member(Long id, OauthInfo oauthInfo, Integer age, Gender gender, Role role){
+    public Member(Long id, String nickName, OauthInfo oauthInfo, Integer age, Gender gender, Role role,Status status, LocalDateTime createAt, LocalDateTime updateAt){
         this.id = id;
+        this.nickName = nickName;
         this.oauthInfo =oauthInfo;
         this.age =age;
         this.gender = gender;
         this.role = role;
+        this.status = status;
+        this.createAt = createAt;
+        this.updateAt = updateAt;
     }
 
 }

--- a/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/Entitiy/MemberEntity.java
+++ b/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/Entitiy/MemberEntity.java
@@ -1,8 +1,10 @@
 package com.ureca.gate.member.infrastructure.jpaAdapter.Entitiy;
 
 
+import com.ureca.gate.global.entity.BaseTimeEntity;
 import com.ureca.gate.member.domain.Enum.Gender;
 import com.ureca.gate.member.domain.Enum.Role;
+import com.ureca.gate.member.domain.Enum.Status;
 import com.ureca.gate.member.domain.Member;
 import com.ureca.gate.member.domain.OauthInfo;
 import jakarta.persistence.*;
@@ -10,35 +12,44 @@ import lombok.Getter;
 
 @Entity
 @Getter
-public class MemberEntity {
+public class MemberEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
 
-    private Integer age;
+    private String nickName;
 
-    private Gender gender;
+    private Integer age;
 
     @Embedded
     private OauthInfo oauthInfo;
 
     @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
     private Role role;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     public static MemberEntity fromOauth(OauthInfo oauthInfo){
         MemberEntity userEntity = new MemberEntity();
         userEntity.oauthInfo = oauthInfo;
         userEntity.role = Role.USER;
+        userEntity.status = Status.NONACTIVE;
         return userEntity;
     }
     public static MemberEntity from(Member member){
         MemberEntity memberEntity = new MemberEntity();
         memberEntity.oauthInfo = member.getOauthInfo();
+        memberEntity.nickName = member.getNickName();
         memberEntity.age = member.getAge();
         memberEntity.gender = member.getGender();
         memberEntity.role = member.getRole();
+        memberEntity.status = member.getStatus();
         return memberEntity;
     }
 
@@ -46,7 +57,13 @@ public class MemberEntity {
         return Member.builder()
                 .id(id)
                 .oauthInfo(oauthInfo)
+                .nickName(nickName)
                 .role(role)
+                .age(age)
+                .gender(gender)
+                .status(status)
+                .createAt(getCreateAt())  // BaseTimeEntity에서 상속받은 createAt
+                .updateAt(getUpdateAt())  // BaseTimeEntity에서 상속받은 updateAt
                 .build();
     }
 

--- a/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/MemberJpaRepository.java
+++ b/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/MemberJpaRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 
 public interface MemberJpaRepository extends JpaRepository<MemberEntity,Long> {
     Optional<MemberEntity> findByOauthInfoOid(String oid);
+
+    boolean existsByNickName(String nickName);
 }

--- a/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/MemberRepositoryImpl.java
+++ b/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/MemberRepositoryImpl.java
@@ -42,4 +42,10 @@ public class MemberRepositoryImpl implements MemberRepository {
         return memberJpaRepository.findById(id).map(MemberEntity::toModel);
     }
 
+
+    @Override
+    public boolean existsByNickname(String nickName){
+        return memberJpaRepository.existsByNickName(nickName);
+    }
+
 }


### PR DESCRIPTION


> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - x

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 닉네임 중복체크 API 구현
    - Member 도메인에 status 필드 추가하여 회원 상태 관리
      - 로그인/회원가입 시 응답에 status 필드를 포함
      - status가 NONACTIVE일 경우, 추가정보 입력 페이지로 리다이렉션 여부 확인

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - x

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : YES - Member 도메인에 변수 추가

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
