### PR TITLE
feat: [GATE-25] 회원가입 API (추가정보 입력) 구현

### DIFF
--- a/src/main/java/com/ureca/gate/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/ureca/gate/member/application/MemberServiceImpl.java
@@ -4,12 +4,17 @@ import com.ureca.gate.global.exception.custom.BusinessException;
 import com.ureca.gate.member.application.outputport.MemberRepository;
 import com.ureca.gate.member.controller.inputport.MemberService;
 import com.ureca.gate.member.controller.request.NicknameCheckRequest;
+import com.ureca.gate.member.controller.request.SignUpAddInfoRequest;
+import com.ureca.gate.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.ureca.gate.global.exception.errorcode.CommonErrorCode.USER_DUPLICATE_NICKNAME;
+import static com.ureca.gate.global.exception.errorcode.CommonErrorCode.USER_NOT_FOUND;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
@@ -20,5 +25,16 @@ public class MemberServiceImpl implements MemberService {
             throw new BusinessException(USER_DUPLICATE_NICKNAME);
         }
     }
+
+    @Override
+    @Transactional
+    public void signUpAddInfo(Long userId, SignUpAddInfoRequest signUpAddInfoRequest){
+        Member member = memberRepository.findById(userId).orElseThrow(()->new BusinessException(USER_NOT_FOUND));
+        member.AdditionalInfo(signUpAddInfoRequest.getNickName(), signUpAddInfoRequest.getBirthday(), signUpAddInfoRequest.getGender());
+
+        memberRepository.save(member);
+
+    }
+
 
 }

--- a/src/main/java/com/ureca/gate/member/application/outputport/MemberRepository.java
+++ b/src/main/java/com/ureca/gate/member/application/outputport/MemberRepository.java
@@ -7,12 +7,9 @@ import java.util.Optional;
 
 public interface MemberRepository {
     public Optional<Member> findByOauthInfoOid(String Oid);
-    public Member save(Member member);
-
-    public Optional<Member> findById(Long id);
-
     public Member forceJoin(OauthInfo oauthInfo);
-
+    public Member save(Member member);
+    public Optional<Member> findById(Long id);
     public boolean existsByNickname(String nickName);
 
 }

--- a/src/main/java/com/ureca/gate/member/controller/MemberController.java
+++ b/src/main/java/com/ureca/gate/member/controller/MemberController.java
@@ -4,9 +4,11 @@ import com.ureca.gate.global.dto.response.SuccessResponse;
 import com.ureca.gate.member.controller.inputport.AuthenticationService;
 import com.ureca.gate.member.controller.inputport.MemberService;
 import com.ureca.gate.member.controller.request.NicknameCheckRequest;
+import com.ureca.gate.member.controller.request.SignUpAddInfoRequest;
 import com.ureca.gate.member.controller.response.MemberSignInResponse;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -31,5 +33,13 @@ public class MemberController {
         memberService.checkNickname(nicknameCheckRequest);
         return SuccessResponse.success("사용 가능한 닉네임입니다.");
     }
+
+    @PostMapping("/signup")
+    public SuccessResponse<String> signUpAddInfo(@AuthenticationPrincipal Long userId, @RequestBody SignUpAddInfoRequest signUpAddInfoRequest){
+        memberService.signUpAddInfo(userId,signUpAddInfoRequest);
+        return SuccessResponse.success("완료되었습니다.");
+    }
+
+
 
 }

--- a/src/main/java/com/ureca/gate/member/controller/inputport/MemberService.java
+++ b/src/main/java/com/ureca/gate/member/controller/inputport/MemberService.java
@@ -1,10 +1,13 @@
 package com.ureca.gate.member.controller.inputport;
 
 import com.ureca.gate.member.controller.request.NicknameCheckRequest;
+import com.ureca.gate.member.controller.request.SignUpAddInfoRequest;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface MemberService {
 
     void checkNickname(NicknameCheckRequest nicknameCheckRequest);
+
+    void signUpAddInfo(Long userId, SignUpAddInfoRequest signUpAddInfoRequest );
 }

--- a/src/main/java/com/ureca/gate/member/controller/request/SignUpAddInfoRequest.java
+++ b/src/main/java/com/ureca/gate/member/controller/request/SignUpAddInfoRequest.java
@@ -1,0 +1,14 @@
+package com.ureca.gate.member.controller.request;
+
+import com.ureca.gate.member.domain.Enum.Gender;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class SignUpAddInfoRequest {
+    private String nickName;
+    private LocalDate birthday;
+    private Gender gender;
+
+}

--- a/src/main/java/com/ureca/gate/member/domain/Member.java
+++ b/src/main/java/com/ureca/gate/member/domain/Member.java
@@ -6,6 +6,7 @@ import com.ureca.gate.member.domain.Enum.Status;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -13,7 +14,7 @@ public class Member {
     private Long id;
     private String nickName;
     private OauthInfo oauthInfo;
-    private Integer age;
+    private LocalDate birthday;
     private Gender gender;
     private Role role;
     private Status status;
@@ -21,16 +22,24 @@ public class Member {
     private LocalDateTime updateAt;
 
     @Builder
-    public Member(Long id, String nickName, OauthInfo oauthInfo, Integer age, Gender gender, Role role,Status status, LocalDateTime createAt, LocalDateTime updateAt){
+    public Member(Long id, String nickName, OauthInfo oauthInfo, LocalDate birthday, Gender gender, Role role,Status status, LocalDateTime createAt, LocalDateTime updateAt){
         this.id = id;
         this.nickName = nickName;
         this.oauthInfo =oauthInfo;
-        this.age =age;
+        this.birthday =birthday;
         this.gender = gender;
         this.role = role;
         this.status = status;
         this.createAt = createAt;
         this.updateAt = updateAt;
     }
+
+    public void AdditionalInfo(String nickName,LocalDate birthday,Gender gender){
+        this.nickName = nickName;
+        this.birthday = birthday;
+        this.gender = gender;
+        this.status = Status.ACTIVE;
+    }
+
 
 }

--- a/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/Entitiy/MemberEntity.java
+++ b/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/Entitiy/MemberEntity.java
@@ -10,6 +10,8 @@ import com.ureca.gate.member.domain.OauthInfo;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 public class MemberEntity extends BaseTimeEntity {
@@ -21,7 +23,7 @@ public class MemberEntity extends BaseTimeEntity {
 
     private String nickName;
 
-    private Integer age;
+    private LocalDate birthday;
 
     @Embedded
     private OauthInfo oauthInfo;
@@ -44,9 +46,10 @@ public class MemberEntity extends BaseTimeEntity {
     }
     public static MemberEntity from(Member member){
         MemberEntity memberEntity = new MemberEntity();
+        memberEntity.id = member.getId();
         memberEntity.oauthInfo = member.getOauthInfo();
         memberEntity.nickName = member.getNickName();
-        memberEntity.age = member.getAge();
+        memberEntity.birthday = member.getBirthday();
         memberEntity.gender = member.getGender();
         memberEntity.role = member.getRole();
         memberEntity.status = member.getStatus();
@@ -59,7 +62,7 @@ public class MemberEntity extends BaseTimeEntity {
                 .oauthInfo(oauthInfo)
                 .nickName(nickName)
                 .role(role)
-                .age(age)
+                .birthday(birthday)
                 .gender(gender)
                 .status(status)
                 .createAt(getCreateAt())  // BaseTimeEntity에서 상속받은 createAt

--- a/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/MemberRepositoryImpl.java
+++ b/src/main/java/com/ureca/gate/member/infrastructure/jpaAdapter/MemberRepositoryImpl.java
@@ -29,7 +29,6 @@ public class MemberRepositoryImpl implements MemberRepository {
         return memberJpaRepository.save(MemberEntity.from(member)).toModel();
     }
 
-
     @Override
     @Transactional
     public Member forceJoin(OauthInfo oauthInfo) {
@@ -41,7 +40,6 @@ public class MemberRepositoryImpl implements MemberRepository {
     public Optional<Member> findById(Long id) {
         return memberJpaRepository.findById(id).map(MemberEntity::toModel);
     }
-
 
     @Override
     public boolean existsByNickname(String nickName){


### PR DESCRIPTION

> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - x

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    -  닉네임,생년월일,성별 추가입력 구현

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

     - 헥사고날 아키텍처 방법으로 패키지화하여, 도메인객체와 Entity객체를 분리하였음. 이에 따라, MemberServiceImpl - signUpAddInfo메소드에서 pk를 가지고 엔티티객체를 조회하여 도메인객체를 불러왔음. 이를 수정하고 JPA에 따른 변경감지를 사용하여 업데이트를 진행하려고 하였으나, 수정한 객체는 도메인 객체라 영속성 컨텍스트에서 관리하지않으므로 변경감지가 일어나지 않음.
     -> 그렇기에 save()로 entitiy객체로 변화해서 update함 그랬을때, merge()가 발생하지않을지..? 생각해볼 필요가 있음.

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : Yes  - member 필드 수정

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
