### PR TITLE
feat: [GATE-32] 시설 리스트 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,14 @@ dependencies {
 	//openclient
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.1'
 
+	//Querydsl 추가
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	//공간 인덱스 사용
+	implementation 'org.hibernate.orm:hibernate-spatial:6.2.9.Final'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
@@ -52,3 +60,9 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+clean {
+	delete file('src/main/generated')
+}
+
+

--- a/src/main/java/com/ureca/gate/GateApplication.java
+++ b/src/main/java/com/ureca/gate/GateApplication.java
@@ -1,8 +1,11 @@
 package com.ureca.gate;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
@@ -14,4 +17,8 @@ public class GateApplication {
 		SpringApplication.run(GateApplication.class, args);
 	}
 
+	@Bean
+	JPAQueryFactory jpaQueryFactory(EntityManager em){
+		return new JPAQueryFactory(em);
+	}
 }

--- a/src/main/java/com/ureca/gate/place/application/PlaceListServiceImpl.java
+++ b/src/main/java/com/ureca/gate/place/application/PlaceListServiceImpl.java
@@ -1,0 +1,34 @@
+package com.ureca.gate.place.application;
+
+import com.ureca.gate.dog.domain.enumeration.Size;
+import com.ureca.gate.place.application.outputport.PlaceRepository;
+import com.ureca.gate.place.controller.inputport.PlaceListService;
+import com.ureca.gate.place.controller.response.PlaceResponse;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PlaceListServiceImpl implements PlaceListService {
+    private final PlaceRepository placeRepository;
+    private static final GeometryFactory geometryFactory = new GeometryFactory();
+
+    @Override
+    public List<PlaceResponse> getPlaceList(Double latitude, Double longitude, String category, Size size, List<String> entryConditions, List<String> types) {
+
+        Point userLocation = geometryFactory.createPoint(new Coordinate(longitude, latitude));
+        userLocation.setSRID(4326); // SRID 4326 (WGS 84 좌표계)로 설정
+
+        return placeRepository.findByQueryDsl(userLocation,category,size,entryConditions,types).stream()
+                .map(PlaceResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/ureca/gate/place/controller/PlaceController.java
+++ b/src/main/java/com/ureca/gate/place/controller/PlaceController.java
@@ -1,17 +1,18 @@
 package com.ureca.gate.place.controller;
 
+import com.ureca.gate.dog.domain.enumeration.Size;
 import com.ureca.gate.global.dto.response.SuccessResponse;
 import com.ureca.gate.place.controller.inputport.PlaceCategoryService;
 import com.ureca.gate.place.controller.inputport.PlaceDetailService;
+import com.ureca.gate.place.controller.inputport.PlaceListService;
 import com.ureca.gate.place.controller.response.PlaceCategoryResponse;
 import com.ureca.gate.place.controller.response.PlaceDetailResponse;
+import com.ureca.gate.place.controller.response.PlaceResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,6 +23,7 @@ import java.util.List;
 public class PlaceController {
     private final PlaceCategoryService placeCategoryService;
     private final PlaceDetailService placeDetailService;
+    private final PlaceListService placeListService;
 
     @Operation(summary = "카테고리 리스트 조회 API", description = "장소 카테고리 리스트 조회 API")
     @GetMapping("/categories")
@@ -34,6 +36,26 @@ public class PlaceController {
     @GetMapping("/{placeId}")
     public SuccessResponse<PlaceDetailResponse> getPlaceDetail(@PathVariable("placeId")Long placeId) {
         PlaceDetailResponse response = placeDetailService.getPlaceDetail(placeId);
+        return SuccessResponse.success(response);
+    }
+    @Operation(summary = "시설 리스트 조회 API", description = "시설(장소) 리스트 조회 API")
+    @GetMapping("")
+    public SuccessResponse<List<PlaceResponse>> searchCities(@RequestParam("latitude") Double latitude,
+                                                             @RequestParam("longitude") Double longitude,
+                                                             @Parameter(description = "카테고리. 가능한 값: [의료,미용,반려동물용품,식당,카페,숙소,문화시설,여행지]",
+                                                                     example = "의료")
+                                                             @RequestParam(value = "category", required = false) String category,
+                                                             @Parameter(description = "사이즈. 가능한 값: [LARGE,MEDIUM,SMALL]",
+                                                                     example = "LARGE")
+                                                             @RequestParam(value = "size", required = false) Size size,
+                                                             @Parameter(description = "입장 제한 조건. 가능한 값: [isLeashRequired(목줄), isMuzzleRequired(입마개), isCageRequired(케이지), isVaccinationComplete(접종여부)]",
+                                                                     example = "isLeashRequired,isMuzzleRequired")
+                                                             @RequestParam(value = "entryConditions", required = false) List<String> entryConditions,
+                                                             @Parameter(description = "타입 조건. 가능한 값: [parkingAvailable(주차 가능여부), indoorAvailable(실내 가능여부), outdoorAvailable(실외 가능여부)]",
+                                                                     example = "parkingAvailable,indoorAvailable")
+                                                             @RequestParam(value = "types", required = false) List<String> types) {
+
+        List<PlaceResponse> response = placeListService.getPlaceList(latitude, longitude, category, size, entryConditions, types);
         return SuccessResponse.success(response);
     }
 

--- a/src/main/java/com/ureca/gate/place/controller/inputport/PlaceListService.java
+++ b/src/main/java/com/ureca/gate/place/controller/inputport/PlaceListService.java
@@ -1,0 +1,11 @@
+package com.ureca.gate.place.controller.inputport;
+
+import com.ureca.gate.dog.domain.enumeration.Size;
+import com.ureca.gate.place.controller.response.PlaceResponse;
+
+import java.util.List;
+
+public interface PlaceListService {
+
+    public List<PlaceResponse> getPlaceList(Double latitude, Double longitude, String category, Size size, List<String> entryConditions, List<String> types);
+}

--- a/src/main/java/com/ureca/gate/place/controller/response/PlaceResponse.java
+++ b/src/main/java/com/ureca/gate/place/controller/response/PlaceResponse.java
@@ -1,0 +1,35 @@
+package com.ureca.gate.place.controller.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlaceResponse {
+    @Schema(description = "장소 아이디", example = "1")
+    private Long id;
+    @Schema(description = "장소 이름", example = "멍멍이카페")
+    private String name;
+    @Schema(description = "장소 카테고리", example = "카페")
+    private String category;
+    @Schema(description = "도로명주소", example = "경기도 고양시 덕양구 동세로 19")
+    private String roadAddress; //도로명 주소
+    @Schema(description = "우편주소", example = "12465")
+    private String postalCode; //우편주소
+//    @Schema(description = "평균별", example = "4.5")
+//    private float star;
+//    @Schema(description = "리뷰수", example = "1")
+//    private Integer reviewNum;
+
+
+    public static PlaceResponse from(com.ureca.gate.place.infrastructure.dto.PlaceResponse place){
+        return PlaceResponse.builder()
+                .id(place.getId())
+                .name(place.getName())
+                .category(place.getCategory())
+                .roadAddress(place.getRoadAddress())
+                .postalCode(place.getPostalCode())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/gate/place/domain/Place.java
+++ b/src/main/java/com/ureca/gate/place/domain/Place.java
@@ -5,6 +5,7 @@ import com.ureca.gate.dog.domain.enumeration.Size;
 import com.ureca.gate.place.domain.enumeration.YesNo;
 import lombok.Builder;
 import lombok.Getter;
+import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,8 +16,7 @@ public class Place {
     private Long id;
     private String name;
     private Category category;
-    private Double latitude;
-    private Double longitude;
+    private Point locationPoint;
     private String postalCode; //우편번호
     private String roadAddress; //도로명
     private String lotAddress; //지번번호

--- a/src/main/java/com/ureca/gate/place/domain/enumeration/YesNo.java
+++ b/src/main/java/com/ureca/gate/place/domain/enumeration/YesNo.java
@@ -1,6 +1,5 @@
 package com.ureca.gate.place.domain.enumeration;
 
-import com.ureca.gate.dog.domain.enumeration.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/ureca/gate/place/infrastructure/dto/PlaceResponse.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/dto/PlaceResponse.java
@@ -1,0 +1,39 @@
+package com.ureca.gate.place.infrastructure.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.ureca.gate.place.infrastructure.jpaadapter.entity.PlaceEntity;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlaceResponse {
+    private Long id;
+    private String name;
+    private String category;
+    private String roadAddress; //도로명 주소
+    private String postalCode; //우편주소
+//    private float star;
+//    private Integer reviewNum;
+
+    @QueryProjection
+    public PlaceResponse(Long id, String name, String category, String roadAddress, String postalCode) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.roadAddress = roadAddress;
+        this.postalCode = postalCode;
+//        this.star = star;
+//        this.reviewNum = reviewNum;
+    }
+
+    public static PlaceResponse from(PlaceEntity placeEntity){
+        return PlaceResponse.builder()
+                .id(placeEntity.getId())
+                .name(placeEntity.getName())
+                .category(placeEntity.getCategoryEntity().getName())
+                .roadAddress(placeEntity.getAddress().getRoadAddress())
+                .postalCode(placeEntity.getAddress().getPostalCode())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceCategoryRepositoryImpl.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceCategoryRepositoryImpl.java
@@ -1,6 +1,5 @@
 package com.ureca.gate.place.infrastructure.jpaadapter;
 
-import com.ureca.gate.member.infrastructure.jpaadapter.entity.MemberEntity;
 import com.ureca.gate.place.application.outputport.PlaceCategoryRepository;
 import com.ureca.gate.place.domain.Category;
 import com.ureca.gate.place.infrastructure.jpaadapter.entity.CategoryEntity;

--- a/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceJpaRepository.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceJpaRepository.java
@@ -3,5 +3,5 @@ package com.ureca.gate.place.infrastructure.jpaadapter;
 import com.ureca.gate.place.infrastructure.jpaadapter.entity.PlaceEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PlaceJpaRepository extends JpaRepository<PlaceEntity,Long> {
+public interface PlaceJpaRepository extends JpaRepository<PlaceEntity,Long>,PlaceRepositoryCustom {
 }

--- a/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceRepositoryCustom.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceRepositoryCustom.java
@@ -1,16 +1,13 @@
-package com.ureca.gate.place.application.outputport;
+package com.ureca.gate.place.infrastructure.jpaadapter;
 
 import com.ureca.gate.dog.domain.enumeration.Size;
-import com.ureca.gate.place.domain.Category;
-import com.ureca.gate.place.domain.Place;
 import com.ureca.gate.place.infrastructure.dto.PlaceResponse;
 import org.locationtech.jts.geom.Point;
 
 import java.util.List;
-import java.util.Optional;
 
-public interface PlaceRepository {
-    Optional<Place> findById(Long placeId);
 
+public interface PlaceRepositoryCustom {
     List<PlaceResponse> findByQueryDsl(Point userLocation, String category, Size size, List<String> entryConditions, List<String> types);
+
 }

--- a/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceRepositoryCustomImpl.java
@@ -1,0 +1,132 @@
+package com.ureca.gate.place.infrastructure.jpaadapter;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.gate.dog.domain.enumeration.Size;
+import com.ureca.gate.place.infrastructure.dto.PlaceResponse;
+import com.ureca.gate.place.infrastructure.dto.QPlaceResponse;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.ureca.gate.place.infrastructure.jpaadapter.entity.QCategoryEntity.categoryEntity;
+import static com.ureca.gate.place.infrastructure.jpaadapter.entity.QPlaceEntity.placeEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class PlaceRepositoryCustomImpl implements PlaceRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PlaceResponse> findByQueryDsl(Point userLocation, String category, Size size, List<String> entryConditions, List<String> types) {
+        return queryFactory
+                .select(new QPlaceResponse(
+                        placeEntity.id,
+                        placeEntity.name,
+                        placeEntity.categoryEntity.name,
+                        placeEntity.address.roadAddress,
+                        placeEntity.address.postalCode)
+                )
+                .from(placeEntity)
+                .leftJoin(placeEntity.categoryEntity,categoryEntity)
+                .where(
+                        isWithinBuffer(userLocation, 1000),// 반경 조건
+                        matchesCategory(category),
+                        matchesSize(size), //사이즈
+                        matchesEntryConditionsAnd(entryConditions), //제한사항
+                        matchesTypes(types) // 타입 조건 추가
+                )
+                .fetch();
+    }
+
+    // 반경 조건 (ST_Buffer + ST_Contains 활용)
+    private BooleanExpression isWithinBuffer(Point userLocation, double radiusMeters) {
+        return Expressions.booleanTemplate(
+                "ST_Contains(ST_Buffer(ST_GeomFromText({0}, 4326), {1}), {2})",
+                "POINT(" + userLocation.getY() + " " + userLocation.getX() + ")", // 사용자 위치
+                radiusMeters,                                                    // 반경
+                placeEntity.address.locationPoint                                                   // 장소 위치
+        );
+    }
+    // 카테고리 조건
+    private BooleanExpression matchesCategory(String category) {
+        if (category == null) {
+            return null; // 조건이 없으면 필터링하지 않음
+        }
+
+        return JPAExpressions
+                .select(categoryEntity.name) // 부모 이름 또는 자신의 이름 반환
+                .from(categoryEntity)
+                .where(
+                        categoryEntity.eq(placeEntity.categoryEntity) // 현재 카테고리 매칭
+                                .and(categoryEntity.parentCategory.isNull()) // 부모 없음
+                                .or(categoryEntity.id.eq(placeEntity.categoryEntity.parentCategory.id)) // 부모 있음
+                )
+                .eq(category);
+    }
+
+    // 사이즈 조건
+    private BooleanExpression matchesSize(Size size) {
+        return size != null ? placeEntity.size.eq(size.name()) : null;
+    }
+    //입장조건
+    private BooleanExpression matchesEntryConditionsAnd(List<String> entryConditions) {
+        if (entryConditions == null || entryConditions.isEmpty()) {
+            return null; // 조건이 없으면 필터링하지 않음
+        }
+
+        return entryConditions.stream()
+                .map(this::mapConditionToExpression) // 각 조건을 BooleanExpression으로 변환
+                .reduce(BooleanExpression::and)     // AND로 연결
+                .orElse(null);                      // 조건이 없으면 null 반환
+    }
+
+    // 조건 이름을 BooleanExpression으로 매핑
+    private BooleanExpression mapConditionToExpression(String condition) {
+        switch (condition) {
+            case "isLeashRequired":
+                return placeEntity.isLeashRequired.eq("Y"); // "Y"로 필터링
+            case "isMuzzleRequired":
+                return placeEntity.isMuzzleRequired.eq("Y");
+            case "isCageRequired":
+                return placeEntity.isCageRequired.eq("Y");
+            case "isVaccinationComplete":
+                return placeEntity.isVaccinationComplete.eq("Y");
+            default:
+                throw new IllegalArgumentException("Unknown entry condition: " + condition);
+        }
+    }
+    private BooleanExpression matchesTypes(List<String> types) {
+        if (types == null || types.isEmpty()) {
+            return null; // 조건이 없으면 필터링하지 않음
+        }
+
+        return types.stream()
+                .map(this::mapTypeToExpression) // 각 타입을 BooleanExpression으로 변환
+                .filter(Objects::nonNull)      // 유효한 조건만 포함
+                .reduce(BooleanExpression::and) // AND로 연결
+                .orElse(null);                  // 조건이 없으면 null 반환
+    }
+
+    // 각 타입을 BooleanExpression으로 매핑
+    private BooleanExpression mapTypeToExpression(String type) {
+        switch (type) {
+            case "parkingAvailable":
+                return placeEntity.parkingAvailable.eq("Y");
+            case "indoorAvailable":
+                return placeEntity.indoorAvailable.eq("Y");
+            case "outdoorAvailable":
+                return placeEntity.outdoorAvailable.eq("Y");
+            default:
+                throw new IllegalArgumentException("Unknown type condition: " + type);
+        }
+    }
+
+
+}

--- a/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceRepositoryImpl.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceRepositoryImpl.java
@@ -1,11 +1,15 @@
 package com.ureca.gate.place.infrastructure.jpaadapter;
 
+import com.ureca.gate.dog.domain.enumeration.Size;
 import com.ureca.gate.place.application.outputport.PlaceRepository;
 import com.ureca.gate.place.domain.Place;
+import com.ureca.gate.place.infrastructure.dto.PlaceResponse;
 import com.ureca.gate.place.infrastructure.jpaadapter.entity.PlaceEntity;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,8 +17,18 @@ import java.util.Optional;
 public class PlaceRepositoryImpl implements PlaceRepository {
 
     private final PlaceJpaRepository placeJpaRepository;
+
     @Override
     public Optional<Place> findById(Long placeId) {
         return placeJpaRepository.findById(placeId).map(PlaceEntity::toModel);
     }
+
+    @Override
+    public List<PlaceResponse> findByQueryDsl(Point userLocation, String category, Size size, List<String> entryConditions, List<String> types){
+        return placeJpaRepository.findByQueryDsl(userLocation,category,size,entryConditions,types);
+
+    }
+
+
+
 }

--- a/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/entity/PlaceEntity.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/entity/PlaceEntity.java
@@ -8,6 +8,7 @@ import com.ureca.gate.place.domain.enumeration.YesNo;
 import com.ureca.gate.place.infrastructure.jpaadapter.entity.vo.Address;
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDate;
 
@@ -58,8 +59,7 @@ public class PlaceEntity extends BaseTimeEntity {
                 .id(id)
                 .name(name)
                 .category(categoryEntity.toModel())
-                .latitude(address.getLatitude())
-                .longitude(address.getLongitude())
+                .locationPoint(address.getLocationPoint())
                 .postalCode(address.getPostalCode()) //우편번호
                 .roadAddress(address.getRoadAddress())  //도로명
                 .lotAddress(address.getLotAddress())  //지번번호

--- a/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/entity/vo/Address.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/entity/vo/Address.java
@@ -1,10 +1,12 @@
 package com.ureca.gate.place.infrastructure.jpaadapter.entity.vo;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 
 @Getter
 @Embeddable
@@ -17,14 +19,14 @@ public class Address {
     private String lotNumber;
     private String road;
     private String buildingNumber;
-    private Double latitude;
-    private Double longitude;
+    @Column(nullable = false, columnDefinition = "POINT SRID 4326")
+    private Point locationPoint; // Point(경도, 위도)
     private String postalCode;
     private String roadAddress;
     private String lotAddress;
 
     @Builder
-    public Address(String city, String district, String town, String village, String lotNumber, String road, String buildingNumber, Double latitude, Double longitude, String postalCode, String roadAddress, String lotAddress) {
+    public Address(String city, String district, String town, String village, String lotNumber, String road, String buildingNumber, Point locationPoint, String postalCode, String roadAddress, String lotAddress) {
         this.city = city;
         this.district = district;
         this.town = town;
@@ -32,8 +34,7 @@ public class Address {
         this.lotNumber = lotNumber;
         this.road = road;
         this.buildingNumber = buildingNumber;
-        this.latitude = latitude;
-        this.longitude = longitude;
+        this.locationPoint = locationPoint;
         this.postalCode = postalCode;
         this.roadAddress = roadAddress;
         this.lotAddress = lotAddress;


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - https://velog.io/@kekim20/MySQL-%EB%B0%98%EA%B2%BD-n-km%EB%82%B4-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%A1%B0%ED%9A%8C-%EA%B3%B5%EA%B0%84-%EC%9D%B8%EB%8D%B1%EC%8A%A4-%EC%A0%81%EC%9A%A9%EC%8B%9C-%EC%A3%BC%EC%9D%98%ED%95%A0-%EC%A0%90
    - https://velog.io/@jjh0526/JPA%EC%99%80-Hibernate-Spatial%EB%A1%9C-MySQL-Point-%ED%83%80%EC%9E%85%EA%B3%B5%EA%B0%84-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-%EA%B3%B5%EA%B0%84-%EB%8D%B0%EC%9D%B4%ED%84%B0%EB%B2%A0%EC%9D%B4%EC%8A%A4-%EC%9C%84%EB%8F%84-%EA%B2%BD%EB%8F%84

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 위도/경도 기반 반경 내 시설 리스트 조회 기능 추가
    - 카테고리, 사이즈, 입장 조건, 타입 필터링 기능 구현
    - QPlaceResponse 및 DTO 변환 로직 적용
    - 공간 인덱스와 QueryDSL을 활용한 효율적 조회 처리

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 현재 리뷰 별점 평점과 즐겨찾기는 구현 미완료

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : YES

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] :
    -  //Querydsl 추가
	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
	//공간 인덱스 사용
	implementation 'org.hibernate.orm:hibernate-spatial:6.2.9.Final'
