### PR TITLE
feat: [GATE-33] 즐겨찾기 삭제 API 구현

### DIFF
--- a/src/main/java/com/ureca/gate/favorites/application/FavoritesServiceImpl.java
+++ b/src/main/java/com/ureca/gate/favorites/application/FavoritesServiceImpl.java
@@ -13,8 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.ureca.gate.global.exception.errorcode.CommonErrorCode.MEMBER_NOT_FOUND;
-import static com.ureca.gate.global.exception.errorcode.CommonErrorCode.PLACE_NOT_FOUND;
+import static com.ureca.gate.global.exception.errorcode.CommonErrorCode.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -32,6 +31,13 @@ public class FavoritesServiceImpl implements FavoritesService {
         Place place = placeRepository.findById(placeId).orElseThrow(()->new BusinessException(PLACE_NOT_FOUND));
         Favorites favorites = Favorites.from(member,place);
         return FavoritesResponse.from(favoritesRepository.save(favorites));
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long placeId) {
+        Favorites favorites = favoritesRepository.findByPlaceId(placeId).orElseThrow(()->new BusinessException(FAVORITES_NOT_FOUND));
+        favoritesRepository.delete(favorites);
     }
 
 }

--- a/src/main/java/com/ureca/gate/favorites/application/outputport/FavoritesRepository.java
+++ b/src/main/java/com/ureca/gate/favorites/application/outputport/FavoritesRepository.java
@@ -2,6 +2,11 @@ package com.ureca.gate.favorites.application.outputport;
 
 import com.ureca.gate.favorites.domain.Favorites;
 
+import java.util.Optional;
+
 public interface FavoritesRepository {
     Favorites save(Favorites favorites);
+    Optional<Favorites> findByPlaceId(Long placeId);
+
+    void delete(Favorites favorites);
 }

--- a/src/main/java/com/ureca/gate/favorites/controller/FavoritesController.java
+++ b/src/main/java/com/ureca/gate/favorites/controller/FavoritesController.java
@@ -5,6 +5,7 @@ import com.ureca.gate.favorites.controller.inputport.FavoritesService;
 import com.ureca.gate.favorites.controller.request.FavoritesSaveRequest;
 import com.ureca.gate.favorites.controller.response.FavoritesResponse;
 import com.ureca.gate.global.dto.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,10 +18,19 @@ import org.springframework.web.bind.annotation.*;
 public class FavoritesController {
     private final FavoritesService favoritesService;
     @PostMapping("")
+    @Operation(summary = "즐겨찾기 등록 API", description = "해당 장소 즐겨찾기 삭제 안하고 또 시도시 에러")
     public SuccessResponse<FavoritesResponse> create(@AuthenticationPrincipal Long memberId, @RequestBody FavoritesSaveRequest request){
-        System.out.println(memberId);
         FavoritesResponse response = favoritesService.create(memberId,request.getPlaceId());
         return SuccessResponse.success(response);
     }
+
+    @PatchMapping("/{favoriteId}")
+    @Operation(summary = "즐겨찾기 삭제 API", description = "즐겨찾기 삭제 API")
+    public SuccessResponse<Object> delete(@PathVariable Long favoriteId){
+        favoritesService.delete(favoriteId);
+        return SuccessResponse.successWithoutResult(null);
+    }
+
+
 
 }

--- a/src/main/java/com/ureca/gate/favorites/controller/inputport/FavoritesService.java
+++ b/src/main/java/com/ureca/gate/favorites/controller/inputport/FavoritesService.java
@@ -4,4 +4,6 @@ import com.ureca.gate.favorites.controller.response.FavoritesResponse;
 
 public interface FavoritesService {
     FavoritesResponse create(Long memberId, Long placeId);
+
+    void delete(Long placeId);
 }

--- a/src/main/java/com/ureca/gate/favorites/domain/Favorites.java
+++ b/src/main/java/com/ureca/gate/favorites/domain/Favorites.java
@@ -1,9 +1,6 @@
 package com.ureca.gate.favorites.domain;
 
 
-import com.ureca.gate.dog.controller.request.ProfileSaveRequest;
-import com.ureca.gate.dog.domain.Dog;
-import com.ureca.gate.global.util.file.UploadFile;
 import com.ureca.gate.member.domain.Member;
 import com.ureca.gate.place.domain.Place;
 import lombok.Builder;
@@ -33,6 +30,10 @@ public class Favorites {
                 .member(member)
                 .place(place)
                 .build();
+    }
+
+    public void delete(){
+
     }
 
 }

--- a/src/main/java/com/ureca/gate/favorites/domain/enumeration/FavoritesStatus.java
+++ b/src/main/java/com/ureca/gate/favorites/domain/enumeration/FavoritesStatus.java
@@ -1,0 +1,5 @@
+package com.ureca.gate.favorites.domain.enumeration;
+
+public enum FavoritesStatus {
+    DELETE_Y, DELETE_N
+}

--- a/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/FavoritesJpaRepository.java
+++ b/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/FavoritesJpaRepository.java
@@ -3,5 +3,8 @@ package com.ureca.gate.favorites.infrastructure.jpaadapter;
 import com.ureca.gate.favorites.infrastructure.jpaadapter.entitiy.FavoritesEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FavoritesJpaRepository extends JpaRepository<FavoritesEntity,Long> {
+    Optional<FavoritesEntity> findByPlaceEntityId(Long placeId);
 }

--- a/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/FavoritesRepositoryImpl.java
+++ b/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/FavoritesRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.ureca.gate.favorites.infrastructure.jpaadapter.entitiy.FavoritesEntit
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 
 @Repository
 @RequiredArgsConstructor
@@ -16,4 +18,15 @@ public class FavoritesRepositoryImpl implements FavoritesRepository {
     public Favorites save(Favorites favorites){
         return favoritesJpaRepository.save(FavoritesEntity.from(favorites)).toModel();
     }
+
+    @Override
+    public Optional<Favorites> findByPlaceId(Long placeId) {
+        return favoritesJpaRepository.findByPlaceEntityId(placeId).map(FavoritesEntity::toModel);
+    }
+
+    @Override
+    public void delete(Favorites favorites) {
+        favoritesJpaRepository.delete(FavoritesEntity.from(favorites));
+    }
+
 }

--- a/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/entitiy/FavoritesEntity.java
+++ b/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/entitiy/FavoritesEntity.java
@@ -2,27 +2,33 @@ package com.ureca.gate.favorites.infrastructure.jpaadapter.entitiy;
 
 import com.ureca.gate.favorites.domain.Favorites;
 import com.ureca.gate.global.entity.BaseTimeEntity;
-import com.ureca.gate.member.domain.Member;
 import com.ureca.gate.member.infrastructure.jpaadapter.entity.MemberEntity;
-import com.ureca.gate.place.domain.Place;
 import com.ureca.gate.place.infrastructure.jpaadapter.entity.PlaceEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Table(name ="favorites")
 @Getter
+@SQLDelete(sql = "UPDATE favorites SET delete_yn = 'Y' WHERE favorites_id = ?")
+@Where(clause = "delete_yn = 'N'")
 public class FavoritesEntity extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "favorites_id")
     private Long id;
+
     @JoinColumn(name  = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private MemberEntity memberEntity;
+
     @JoinColumn(name  = "place_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private PlaceEntity placeEntity;
+
+    private String deleteYn = "N";
 
     public static FavoritesEntity from(Favorites favorites){
         FavoritesEntity favoritesEntity = new FavoritesEntity();

--- a/src/main/java/com/ureca/gate/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/ureca/gate/global/exception/errorcode/CommonErrorCode.java
@@ -29,6 +29,9 @@ public enum CommonErrorCode implements ErrorCode{
     //place error (4301~
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND,"4301","해당 장소를 찾을 수 없습니다."),
 
+    //place error (4401~
+    FAVORITES_NOT_FOUND(HttpStatus.NOT_FOUND,"4401","해당 즐겨찾기를 찾을 수 없습니다."),
+
     TEST_NOT_FOUND(HttpStatus.UNAUTHORIZED,"8888","테스트 아이디가 없습니다."),
 
 


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - x

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - @SQLDelete를 사용하여 delete_yn 필드를 업데이트
    - @Where를 사용하여 삭제된 데이터는 기본 조회에서 제외

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - x

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : YES
    - favorite 테이블 내 delete_yn 칼럼 추가 

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
