### PR TITLE
refactor: [GATE-38] 장소 리스트 조회 응답값 수정 & 즐겨찾기 여부 조회 로직 FavoritesService…

### DIFF
--- a/src/main/java/com/ureca/gate/favorites/application/outputport/FavoritesRepository.java
+++ b/src/main/java/com/ureca/gate/favorites/application/outputport/FavoritesRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface FavoritesRepository {
     Favorites save(Favorites favorites);
-    Optional<Favorites> findByPlaceId(Long placeId);
+    Optional<Favorites> findByMemberIdAndPlaceId(Long memberId,Long placeId);
 
     void delete(Favorites favorites);
 

--- a/src/main/java/com/ureca/gate/favorites/controller/FavoritesController.java
+++ b/src/main/java/com/ureca/gate/favorites/controller/FavoritesController.java
@@ -29,8 +29,8 @@ public class FavoritesController {
 
     @PatchMapping("/{favoriteId}")
     @Operation(summary = "즐겨찾기 삭제 API", description = "즐겨찾기 삭제 API")
-    public SuccessResponse<Object> delete(@PathVariable Long favoriteId){
-        favoritesService.delete(favoriteId);
+    public SuccessResponse<Object> delete(@AuthenticationPrincipal Long memberId, @PathVariable Long favoriteId){
+        favoritesService.delete(memberId,favoriteId);
         return SuccessResponse.successWithoutResult(null);
     }
 

--- a/src/main/java/com/ureca/gate/favorites/controller/inputport/FavoritesService.java
+++ b/src/main/java/com/ureca/gate/favorites/controller/inputport/FavoritesService.java
@@ -2,12 +2,15 @@ package com.ureca.gate.favorites.controller.inputport;
 
 import com.ureca.gate.favorites.controller.response.FavoritesEnrollResponse;
 import com.ureca.gate.favorites.controller.response.FavoritesResponse;
+import com.ureca.gate.place.domain.enumeration.YesNo;
 
 import java.util.List;
 
 public interface FavoritesService {
     FavoritesEnrollResponse create(Long memberId, Long placeId);
 
-    void delete(Long placeId);
+    void delete(Long memberId, Long placeId);
     List<FavoritesResponse> getAll(Long memberId);
+
+    YesNo checkIfFavorite(Long memberId, Long placeId);
 }

--- a/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/FavoritesJpaRepository.java
+++ b/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/FavoritesJpaRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FavoritesJpaRepository extends JpaRepository<FavoritesEntity,Long> {
-    Optional<FavoritesEntity> findByPlaceEntityId(Long placeId);
+    Optional<FavoritesEntity> findByMemberEntityIdAndPlaceEntityId(Long memberId, Long placeId);
 
     @Query("SELECT f FROM FavoritesEntity f JOIN FETCH f.placeEntity WHERE f.memberEntity.id = :memberId")
     List<FavoritesEntity> findByMemberEntityIdWithPlace(@Param("memberId") Long memberId);

--- a/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/FavoritesRepositoryImpl.java
+++ b/src/main/java/com/ureca/gate/favorites/infrastructure/jpaadapter/FavoritesRepositoryImpl.java
@@ -24,8 +24,8 @@ public class FavoritesRepositoryImpl implements FavoritesRepository {
     }
 
     @Override
-    public Optional<Favorites> findByPlaceId(Long placeId) {
-        return favoritesJpaRepository.findByPlaceEntityId(placeId).map(FavoritesEntity::toModel);
+    public Optional<Favorites> findByMemberIdAndPlaceId(Long memberId, Long placeId) {
+        return favoritesJpaRepository.findByMemberEntityIdAndPlaceEntityId(memberId,placeId).map(FavoritesEntity::toModel);
     }
 
     @Override

--- a/src/main/java/com/ureca/gate/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/com/ureca/gate/global/exception/errorcode/CommonErrorCode.java
@@ -29,8 +29,11 @@ public enum CommonErrorCode implements ErrorCode{
     //place error (4301~
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND,"4301","해당 장소를 찾을 수 없습니다."),
 
-    //place error (4401~
+    //favorites error (4401~
     FAVORITES_NOT_FOUND(HttpStatus.NOT_FOUND,"4401","해당 즐겨찾기를 찾을 수 없습니다."),
+    FAVORITES_ALREADY_EXISTS(HttpStatus.CONFLICT, "4402", "해당 장소는 이미 즐겨찾기 되었습니다."),
+
+
 
     TEST_NOT_FOUND(HttpStatus.UNAUTHORIZED,"8888","테스트 아이디가 없습니다."),
 

--- a/src/main/java/com/ureca/gate/place/application/PlaceDetailServiceImpl.java
+++ b/src/main/java/com/ureca/gate/place/application/PlaceDetailServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ureca.gate.place.application;
 
 import com.ureca.gate.favorites.application.outputport.FavoritesRepository;
+import com.ureca.gate.favorites.controller.inputport.FavoritesService;
 import com.ureca.gate.favorites.domain.Favorites;
 import com.ureca.gate.global.exception.custom.BusinessException;
 import com.ureca.gate.place.application.outputport.PlaceRepository;
@@ -20,14 +21,11 @@ import static com.ureca.gate.global.exception.errorcode.CommonErrorCode.PLACE_NO
 public class PlaceDetailServiceImpl implements PlaceDetailService {
 
     private final PlaceRepository placeRepository;
-    private final FavoritesRepository favoritesRepository;
+    private final FavoritesService favoritesService;
     @Override
     public PlaceDetailResponse getPlaceDetail(Long memberId,Long placeId) {
         Place place = placeRepository.findById(placeId).orElseThrow(()-> new BusinessException(PLACE_NOT_FOUND));
-        YesNo isFavorite = (memberId != null && favoritesRepository.existsByMemberIdAndPlaceId(memberId, placeId))
-                ? YesNo.Y
-                : YesNo.N;
-        
+        YesNo isFavorite = favoritesService.checkIfFavorite(memberId,placeId);
         return PlaceDetailResponse.from(place,isFavorite);
     }
 

--- a/src/main/java/com/ureca/gate/place/application/PlaceListServiceImpl.java
+++ b/src/main/java/com/ureca/gate/place/application/PlaceListServiceImpl.java
@@ -1,9 +1,12 @@
 package com.ureca.gate.place.application;
 
 import com.ureca.gate.dog.domain.enumeration.Size;
+import com.ureca.gate.favorites.application.outputport.FavoritesRepository;
+import com.ureca.gate.favorites.controller.inputport.FavoritesService;
 import com.ureca.gate.place.application.outputport.PlaceRepository;
 import com.ureca.gate.place.controller.inputport.PlaceListService;
 import com.ureca.gate.place.controller.response.PlaceResponse;
+import com.ureca.gate.place.domain.enumeration.YesNo;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -19,16 +22,20 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PlaceListServiceImpl implements PlaceListService {
     private final PlaceRepository placeRepository;
+    private final FavoritesService favoritesService;
     private static final GeometryFactory geometryFactory = new GeometryFactory();
 
     @Override
-    public List<PlaceResponse> getPlaceList(Double latitude, Double longitude, String category, Size size, List<String> entryConditions, List<String> types) {
+    public List<PlaceResponse> getPlaceList(Long memberId, Double latitude, Double longitude, String category, Size size, List<String> entryConditions, List<String> types) {
 
         Point userLocation = geometryFactory.createPoint(new Coordinate(longitude, latitude));
         userLocation.setSRID(4326); // SRID 4326 (WGS 84 좌표계)로 설정
 
         return placeRepository.findByQueryDsl(userLocation,category,size,entryConditions,types).stream()
-                .map(PlaceResponse::from)
+                .map(place -> {
+                    YesNo isFavorite = favoritesService.checkIfFavorite(memberId, place.getId());
+                    return PlaceResponse.from(place, isFavorite);})
                 .collect(Collectors.toList());
+
     }
 }

--- a/src/main/java/com/ureca/gate/place/controller/PlaceController.java
+++ b/src/main/java/com/ureca/gate/place/controller/PlaceController.java
@@ -45,7 +45,8 @@ public class PlaceController {
     }
     @Operation(summary = "시설 리스트 조회 API", description = "시설(장소) 리스트 조회 API")
     @GetMapping("")
-    public SuccessResponse<List<PlaceResponse>> searchCities(@RequestParam("latitude") Double latitude,
+    public SuccessResponse<List<PlaceResponse>> searchCities(@AuthenticationPrincipal Long memberId,
+                                                             @RequestParam("latitude") Double latitude,
                                                              @RequestParam("longitude") Double longitude,
                                                              @Parameter(description = "카테고리. 가능한 값: [의료,미용,반려동물용품,식당,카페,숙소,문화시설,여행지]",
                                                                      example = "의료")
@@ -60,7 +61,7 @@ public class PlaceController {
                                                                      example = "parkingAvailable,indoorAvailable")
                                                              @RequestParam(value = "types", required = false) List<String> types) {
 
-        List<PlaceResponse> response = placeListService.getPlaceList(latitude, longitude, category, size, entryConditions, types);
+        List<PlaceResponse> response = placeListService.getPlaceList(memberId,latitude, longitude, category, size, entryConditions, types);
         return SuccessResponse.success(response);
     }
 

--- a/src/main/java/com/ureca/gate/place/controller/inputport/PlaceListService.java
+++ b/src/main/java/com/ureca/gate/place/controller/inputport/PlaceListService.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface PlaceListService {
 
-    public List<PlaceResponse> getPlaceList(Double latitude, Double longitude, String category, Size size, List<String> entryConditions, List<String> types);
+    public List<PlaceResponse> getPlaceList(Long memberId,Double latitude, Double longitude, String category, Size size, List<String> entryConditions, List<String> types);
 }

--- a/src/main/java/com/ureca/gate/place/controller/response/PlaceResponse.java
+++ b/src/main/java/com/ureca/gate/place/controller/response/PlaceResponse.java
@@ -1,5 +1,6 @@
 package com.ureca.gate.place.controller.response;
 
+import com.ureca.gate.place.domain.enumeration.YesNo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,27 +14,36 @@ public class PlaceResponse {
     private String name;
     @Schema(description = "장소 카테고리", example = "카페")
     private String category;
+    @Schema(description = "장소 이미지", example = "url")
+    private String profileUrl;
+    @Schema(description = "위도", example = "위도")
     private double latitude;
+    @Schema(description = "경도", example = "경도")
     private double longitude;
     @Schema(description = "도로명주소", example = "경기도 고양시 덕양구 동세로 19")
     private String roadAddress; //도로명 주소
     @Schema(description = "우편주소", example = "12465")
     private String postalCode; //우편주소
+    @Schema(description = "즐겨찾기 여부[Y/N]", example = "N")
+    private YesNo favorites;
+
 //    @Schema(description = "평균별", example = "4.5")
 //    private float star;
 //    @Schema(description = "리뷰수", example = "1")
 //    private Integer reviewNum;
 
 
-    public static PlaceResponse from(com.ureca.gate.place.infrastructure.dto.PlaceResponse place){
+    public static PlaceResponse from(com.ureca.gate.place.infrastructure.dto.PlaceResponse place,YesNo favorites){
         return PlaceResponse.builder()
                 .id(place.getId())
                 .name(place.getName())
                 .category(place.getCategory())
+                .profileUrl(place.getProfileUrl())
                 .latitude(place.getLocationPoint().getY())
                 .longitude(place.getLocationPoint().getX())
                 .roadAddress(place.getRoadAddress())
                 .postalCode(place.getPostalCode())
+                .favorites(favorites)
                 .build();
     }
 }

--- a/src/main/java/com/ureca/gate/place/infrastructure/dto/PlaceResponse.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/dto/PlaceResponse.java
@@ -12,6 +12,7 @@ public class PlaceResponse {
     private Long id;
     private String name;
     private String category;
+    private String profileUrl;
     private Point locationPoint;
     private String roadAddress; //도로명 주소
     private String postalCode; //우편주소
@@ -19,10 +20,11 @@ public class PlaceResponse {
 //    private Integer reviewNum;
 
     @QueryProjection
-    public PlaceResponse(Long id, String name, String category, Point locationPoint,String roadAddress, String postalCode) {
+    public PlaceResponse(Long id, String name, String category, String profileUrl, Point locationPoint,String roadAddress, String postalCode) {
         this.id = id;
         this.name = name;
         this.category = category;
+        this.profileUrl = profileUrl;
         this.locationPoint = locationPoint;
         this.roadAddress = roadAddress;
         this.postalCode = postalCode;
@@ -35,6 +37,7 @@ public class PlaceResponse {
                 .id(placeEntity.getId())
                 .name(placeEntity.getName())
                 .category(placeEntity.getCategoryEntity().getName())
+                .profileUrl(placeEntity.getPhotoUrl())
                 .locationPoint(placeEntity.getAddressEntity().getLocationPoint())
                 .roadAddress(placeEntity.getAddressEntity().getRoadAddress())
                 .postalCode(placeEntity.getAddressEntity().getPostalCode())

--- a/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/jpaadapter/PlaceRepositoryCustomImpl.java
@@ -30,6 +30,7 @@ public class PlaceRepositoryCustomImpl implements PlaceRepositoryCustom {
                         placeEntity.id,
                         placeEntity.name,
                         placeEntity.categoryEntity.name,
+                        placeEntity.photoUrl,
                         placeEntity.addressEntity.locationPoint,
                         placeEntity.addressEntity.roadAddress,
                         placeEntity.addressEntity.postalCode)


### PR DESCRIPTION

> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    - x
> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 장소 리스트 조회 응답값 수정 & 즐겨찾기 여부 조회 로직 FavoritesService로 분리 & 즐겨찾기 등록 및 삭제 수정

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 장소 리스트 조회 응답 내 장소사진, 즐겨찾기 여부 추가
    - 즐겨찾기 여부를 판단하는 로직을 FavoritesServiceImpl의 메서드로 추출하여 중복 제거 및 코드 가독성 개선
    - PlaceListServiceImpl에서 FavoritesService의 checkIfFavorite 메서드를 사용하여 즐겨찾기 여부 설정
    - 즐겨찾기 등록 및 삭제(@AuthenticationPrincipal)추가

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
