### PR TITLE
feat: [GATE-63] 일정 리스트 조회 API

### DIFF
--- a/src/main/java/com/ureca/gate/global/domain/CustomPage.java
+++ b/src/main/java/com/ureca/gate/global/domain/CustomPage.java
@@ -1,0 +1,45 @@
+package com.ureca.gate.global.domain;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class CustomPage<T> {
+
+    private final List<T> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+
+    public static <T, U> CustomPage<U> convert(CustomPage<T> sourcePage, Function<? super T, ? extends U> converter) {
+        List<U> convertedContent = sourcePage.getContent()
+                .stream()
+                .map(converter)
+                .collect(Collectors.toList());
+        return CustomPage.<U>builder()
+                .content(convertedContent)
+                .page(sourcePage.page)
+                .size(sourcePage.size)
+                .totalElements(sourcePage.totalElements)
+                .totalPages(sourcePage.totalPages)
+                .build();
+    }
+
+    public static <T> CustomPage<T> from(Page<T> page) {
+        return CustomPage.<T>builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/gate/global/dto/response/PageResponse.java
+++ b/src/main/java/com/ureca/gate/global/dto/response/PageResponse.java
@@ -1,0 +1,51 @@
+package com.ureca.gate.global.dto.response;
+
+import com.ureca.gate.global.domain.CustomPage;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+public class PageResponse<T> {
+
+    @Schema(description = "콘텐츠")
+    private final List<T> content;
+
+    @Schema(description = "페이지 번호(0 부터 시작)", example = "0")
+    private final int page;
+
+    @Schema(description = "한 페이지에 포함될 항목(데이터)의 개수", example = "10")
+    private final int size;
+
+    @Schema(description = "전체 데이터의 개수", example = "90")
+    private final long totalElements;
+
+    @Schema(description = "전체 페이지 수", example = "9")
+    private final int totalPages;
+
+    @Builder
+    public PageResponse(List<T> content, int page, int size, long totalElements, int totalPages) {
+        this.content = content;
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+    }
+
+    public static <T, U> PageResponse<U> from(CustomPage<T> customPage, Function<? super T, ? extends U> converter) {
+        List<U> convertedContent = customPage.getContent().stream()
+                .map(converter)
+                .collect(Collectors.toList());
+        return PageResponse.<U>builder()
+                .content(convertedContent)
+                .page(customPage.getPage())
+                .size(customPage.getSize())
+                .totalElements(customPage.getTotalElements())
+                .totalPages(customPage.getTotalPages())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/gate/plan/application/PlanServiceImpl.java
+++ b/src/main/java/com/ureca/gate/plan/application/PlanServiceImpl.java
@@ -1,14 +1,21 @@
 package com.ureca.gate.plan.application;
 
+import com.ureca.gate.global.domain.CustomPage;
 import com.ureca.gate.place.application.outputport.CityRepository;
 import com.ureca.gate.place.application.outputport.PlaceRepository;
 import com.ureca.gate.place.domain.City;
 import com.ureca.gate.place.domain.Place;
 import com.ureca.gate.plan.application.command.PlanCreateCommand;
+import com.ureca.gate.plan.application.command.PlanListCommand;
 import com.ureca.gate.plan.application.outputport.PlanRepository;
 import com.ureca.gate.plan.controller.inputport.PlanService;
 import com.ureca.gate.plan.domain.Plan;
+import com.ureca.gate.plan.domain.PlanInfo;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanCommand;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanSearchCondition;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +28,14 @@ public class PlanServiceImpl implements PlanService {
     private final PlanRepository planRepository;
     private final CityRepository cityRepository;
     private final PlaceRepository placeRepository;
+
+    @Transactional(readOnly = true)
+    public CustomPage<PlanInfo> searchPage(PlanListCommand planListCommand) {
+        PlanSearchCondition planSearchCondition = PlanSearchCondition.from(planListCommand);
+        Pageable pageable = PageRequest.of(planListCommand.getPage(), planListCommand.getSize());
+        CustomPage<PlanCommand> planCommandCustomPage = planRepository.searchPage(planSearchCondition, pageable);
+        return CustomPage.convert(planCommandCustomPage, PlanInfo::from);
+    }
 
     @Transactional(readOnly = true)
     public Plan getById(Long planId) {

--- a/src/main/java/com/ureca/gate/plan/application/command/PlanListCommand.java
+++ b/src/main/java/com/ureca/gate/plan/application/command/PlanListCommand.java
@@ -1,0 +1,36 @@
+package com.ureca.gate.plan.application.command;
+
+import com.ureca.gate.plan.controller.request.PlanListRequest;
+import com.ureca.gate.plan.domain.DateFilter;
+import com.ureca.gate.plan.domain.SortOrder;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlanListCommand {
+
+    private final Long memberId;
+    private final DateFilter dateFilter;
+    private final SortOrder sortOrder;
+    private final int page;
+    private final int size;
+
+    public PlanListCommand(Long memberId, DateFilter dateFilter, SortOrder sortOrder, int page, int size) {
+        this.memberId = memberId;
+        this.dateFilter = dateFilter;
+        this.sortOrder = sortOrder;
+        this.page = page;
+        this.size = size;
+    }
+
+    public static PlanListCommand from(Long memberId, PlanListRequest planListRequest) {
+        return PlanListCommand.builder()
+                .memberId(memberId)
+                .dateFilter(planListRequest.getDateFilter())
+                .sortOrder(planListRequest.getSortOrder())
+                .page(planListRequest.getPage())
+                .size(planListRequest.getSize())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/gate/plan/application/outputport/PlanRepository.java
+++ b/src/main/java/com/ureca/gate/plan/application/outputport/PlanRepository.java
@@ -1,8 +1,14 @@
 package com.ureca.gate.plan.application.outputport;
 
+import com.ureca.gate.global.domain.CustomPage;
 import com.ureca.gate.plan.domain.Plan;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanCommand;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanSearchCondition;
+import org.springframework.data.domain.Pageable;
 
 public interface PlanRepository {
+    CustomPage<PlanCommand> searchPage(PlanSearchCondition planSearchCondition, Pageable pageable);
+
     Plan getById(Long planId);
 
     Plan save(Plan plan);

--- a/src/main/java/com/ureca/gate/plan/controller/PlanController.java
+++ b/src/main/java/com/ureca/gate/plan/controller/PlanController.java
@@ -1,14 +1,22 @@
 package com.ureca.gate.plan.controller;
 
+import com.ureca.gate.global.domain.CustomPage;
+import com.ureca.gate.global.dto.response.PageResponse;
 import com.ureca.gate.global.dto.response.SuccessResponse;
 import com.ureca.gate.plan.application.command.PlanCreateCommand;
+import com.ureca.gate.plan.application.command.PlanListCommand;
 import com.ureca.gate.plan.controller.inputport.PlanService;
+import com.ureca.gate.plan.controller.request.PlanListRequest;
 import com.ureca.gate.plan.controller.request.PlanSaveRequest;
+import com.ureca.gate.plan.controller.response.PlanInfoResponse;
 import com.ureca.gate.plan.controller.response.PlanResponse;
 import com.ureca.gate.plan.domain.Plan;
+import com.ureca.gate.plan.domain.PlanInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +27,16 @@ import org.springframework.web.bind.annotation.*;
 public class PlanController {
 
     private final PlanService planService;
+
+    @Operation(summary = "일정 리스트 조회 API", description = "현재 날짜를 기준으로 지난 여행, 다가오는 여행 리스트를 정렬조건에 따라 페이징")
+    @GetMapping
+    public SuccessResponse<PageResponse<PlanInfoResponse>> getAll(@AuthenticationPrincipal Long memberId,
+                                                                  @ParameterObject PlanListRequest planListRequest) {
+        PlanListCommand planListCommand = PlanListCommand.from(memberId, planListRequest);
+        CustomPage<PlanInfo> planCustomPage = planService.searchPage(planListCommand);
+        PageResponse<PlanInfoResponse> from = PageResponse.from(planCustomPage, PlanInfoResponse::from);
+        return SuccessResponse.success(from);
+    }
 
     @Operation(summary = "일정 조회 API", description = "생성된 일정의 세부 정보 조회")
     @GetMapping("/{planId}")

--- a/src/main/java/com/ureca/gate/plan/controller/inputport/PlanService.java
+++ b/src/main/java/com/ureca/gate/plan/controller/inputport/PlanService.java
@@ -1,9 +1,14 @@
 package com.ureca.gate.plan.controller.inputport;
 
+import com.ureca.gate.global.domain.CustomPage;
 import com.ureca.gate.plan.application.command.PlanCreateCommand;
+import com.ureca.gate.plan.application.command.PlanListCommand;
 import com.ureca.gate.plan.domain.Plan;
+import com.ureca.gate.plan.domain.PlanInfo;
 
 public interface PlanService {
+    CustomPage<PlanInfo> searchPage(PlanListCommand planListCommand);
+
     Plan getById(Long planId);
 
     Plan create(PlanCreateCommand planCreateCommand);

--- a/src/main/java/com/ureca/gate/plan/controller/request/PlanListRequest.java
+++ b/src/main/java/com/ureca/gate/plan/controller/request/PlanListRequest.java
@@ -1,0 +1,29 @@
+package com.ureca.gate.plan.controller.request;
+
+import com.ureca.gate.plan.domain.DateFilter;
+import com.ureca.gate.plan.domain.SortOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class PlanListRequest {
+
+    @Schema(description = "AFTER: 다가오는 여행, BEFORE: 지난 여행", example = "AFTER")
+    private final DateFilter dateFilter;
+
+    @Schema(description = "ASC: 오름차순, DESC: 내림차순", example = "ASC")
+    private final SortOrder sortOrder;
+
+    @Schema(description = "페이지 번호, 0 부터 시작", example = "0")
+    private final int page;
+
+    @Schema(description = "한 페이지에 포함될 항목(데이터)의 개수, 최소 1 이상", example = "10")
+    private final int size;
+
+    public PlanListRequest(DateFilter dateFilter, SortOrder sortOrder, int page, int size) {
+        this.dateFilter = dateFilter;
+        this.sortOrder = sortOrder;
+        this.page = page;
+        this.size = size;
+    }
+}

--- a/src/main/java/com/ureca/gate/plan/controller/response/PlanInfoResponse.java
+++ b/src/main/java/com/ureca/gate/plan/controller/response/PlanInfoResponse.java
@@ -1,0 +1,48 @@
+package com.ureca.gate.plan.controller.response;
+
+import com.ureca.gate.plan.domain.PlanInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class PlanInfoResponse {
+
+    @Schema(description = "일정 아이디", example = "1")
+    private final Long id;
+
+    @Schema(description = "도시 이름", example = "경기도")
+    private final String cityName;
+
+    @Schema(description = "여행 날짜", example = "2024-12-05")
+    private final LocalDate date;
+
+    @Schema(description = "동반 반려견 수", example = "2")
+    private final Integer dogSize;
+
+    @Builder
+    public PlanInfoResponse(Long id, String cityName, LocalDate date, Integer dogSize) {
+        this.id = id;
+        this.cityName = cityName;
+        this.date = date;
+        this.dogSize = dogSize;
+    }
+
+    public static List<PlanInfoResponse> from(List<PlanInfo> planCommand) {
+        return planCommand.stream()
+                .map(PlanInfoResponse::from)
+                .toList();
+    }
+
+    public static PlanInfoResponse from(PlanInfo planCommand) {
+        return PlanInfoResponse.builder()
+                .id(planCommand.getId())
+                .cityName(planCommand.getCityName())
+                .date(planCommand.getDate())
+                .dogSize(planCommand.getDogSize())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/gate/plan/domain/DateFilter.java
+++ b/src/main/java/com/ureca/gate/plan/domain/DateFilter.java
@@ -1,0 +1,13 @@
+package com.ureca.gate.plan.domain;
+
+public enum DateFilter {
+    BEFORE, AFTER;
+
+    public boolean isBefore() {
+        return this == BEFORE;
+    }
+
+    public boolean isAfter() {
+        return this == AFTER;
+    }
+}

--- a/src/main/java/com/ureca/gate/plan/domain/PlanInfo.java
+++ b/src/main/java/com/ureca/gate/plan/domain/PlanInfo.java
@@ -1,0 +1,39 @@
+package com.ureca.gate.plan.domain;
+
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanCommand;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+public class PlanInfo {
+    private final Long id;
+    private final String cityName;
+    private final LocalDate date;
+    private final Integer dogSize;
+
+    public PlanInfo(Long id, String cityName, LocalDate date, Integer dogSize) {
+        this.id = id;
+        this.cityName = cityName;
+        this.date = date;
+        this.dogSize = dogSize;
+    }
+
+    public static List<PlanInfo> from(List<PlanCommand> planCommand) {
+        return planCommand.stream()
+                .map(PlanInfo::from)
+                .toList();
+    }
+
+    public static PlanInfo from(PlanCommand planCommand) {
+        return PlanInfo.builder()
+                .id(planCommand.getId())
+                .cityName(planCommand.getCityName())
+                .date(planCommand.getDate())
+                .dogSize(planCommand.getDogSize())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/gate/plan/domain/SortOrder.java
+++ b/src/main/java/com/ureca/gate/plan/domain/SortOrder.java
@@ -1,0 +1,9 @@
+package com.ureca.gate.plan.domain;
+
+public enum SortOrder {
+    ASC, DESC;
+
+    public boolean isDesc() {
+        return this == DESC;
+    }
+}

--- a/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/PlanJpaRepository.java
+++ b/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/PlanJpaRepository.java
@@ -3,5 +3,5 @@ package com.ureca.gate.plan.infrastructure.jpaadapter;
 import com.ureca.gate.plan.infrastructure.jpaadapter.entity.PlanEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PlanJpaRepository extends JpaRepository<PlanEntity, Long> {
+public interface PlanJpaRepository extends JpaRepository<PlanEntity, Long>, PlanRepositoryCustom {
 }

--- a/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/PlanRepositoryCustom.java
+++ b/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/PlanRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.ureca.gate.plan.infrastructure.jpaadapter;
+
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanCommand;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PlanRepositoryCustom {
+    Page<PlanCommand> searchPage(PlanSearchCondition planSearchCondition, Pageable pageable);
+}

--- a/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/PlanRepositoryImpl.java
+++ b/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/PlanRepositoryImpl.java
@@ -1,11 +1,16 @@
 package com.ureca.gate.plan.infrastructure.jpaadapter;
 
+import com.ureca.gate.global.domain.CustomPage;
 import com.ureca.gate.global.exception.custom.BusinessException;
 import com.ureca.gate.global.exception.errorcode.CommonErrorCode;
 import com.ureca.gate.plan.application.outputport.PlanRepository;
 import com.ureca.gate.plan.domain.Plan;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanCommand;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanSearchCondition;
 import com.ureca.gate.plan.infrastructure.jpaadapter.entity.PlanEntity;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
@@ -13,6 +18,12 @@ import org.springframework.stereotype.Repository;
 public class PlanRepositoryImpl implements PlanRepository {
 
     private final PlanJpaRepository planJpaRepository;
+
+    @Override
+    public CustomPage<PlanCommand> searchPage(PlanSearchCondition planSearchCondition, Pageable pageable) {
+        Page<PlanCommand> planCommandCustomPage = planJpaRepository.searchPage(planSearchCondition, pageable);
+        return CustomPage.from(planCommandCustomPage);
+    }
 
     @Override
     public Plan getById(Long planId) {

--- a/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/command/PlanCommand.java
+++ b/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/command/PlanCommand.java
@@ -1,0 +1,23 @@
+package com.ureca.gate.plan.infrastructure.jpaadapter.command;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class PlanCommand {
+
+    private final Long id;
+    private final String cityName;
+    private final LocalDate date;
+    private final Integer dogSize;
+
+    @QueryProjection
+    public PlanCommand(Long id, String cityName, LocalDate date, Integer dogSize) {
+        this.id = id;
+        this.cityName = cityName;
+        this.date = date;
+        this.dogSize = dogSize;
+    }
+}

--- a/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/command/PlanSearchCondition.java
+++ b/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/command/PlanSearchCondition.java
@@ -1,0 +1,30 @@
+package com.ureca.gate.plan.infrastructure.jpaadapter.command;
+
+import com.ureca.gate.plan.application.command.PlanListCommand;
+import com.ureca.gate.plan.domain.DateFilter;
+import com.ureca.gate.plan.domain.SortOrder;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlanSearchCondition {
+
+    private final Long memberId;
+    private final DateFilter dateFilter;
+    private final SortOrder sortOrder;
+
+    public PlanSearchCondition(Long memberId, DateFilter dateFilter, SortOrder sortOrder) {
+        this.memberId = memberId;
+        this.dateFilter = dateFilter;
+        this.sortOrder = sortOrder;
+    }
+
+    public static PlanSearchCondition from(PlanListCommand planListCommand) {
+        return PlanSearchCondition.builder()
+                .memberId(planListCommand.getMemberId())
+                .dateFilter(planListCommand.getDateFilter())
+                .sortOrder(planListCommand.getSortOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/entity/PlanRepositoryCustomImpl.java
+++ b/src/main/java/com/ureca/gate/plan/infrastructure/jpaadapter/entity/PlanRepositoryCustomImpl.java
@@ -1,0 +1,78 @@
+package com.ureca.gate.plan.infrastructure.jpaadapter.entity;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ureca.gate.plan.domain.DateFilter;
+import com.ureca.gate.plan.domain.SortOrder;
+import com.ureca.gate.plan.infrastructure.jpaadapter.PlanRepositoryCustom;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanCommand;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.PlanSearchCondition;
+import com.ureca.gate.plan.infrastructure.jpaadapter.command.QPlanCommand;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static com.ureca.gate.plan.infrastructure.jpaadapter.entity.QPlanEntity.planEntity;
+
+@RequiredArgsConstructor
+public class PlanRepositoryCustomImpl implements PlanRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<PlanCommand> searchPage(PlanSearchCondition planSearchCondition, Pageable pageable) {
+        List<PlanCommand> plans = queryFactory
+                .select(new QPlanCommand(
+                        planEntity.id,
+                        planEntity.city.name,
+                        planEntity.date,
+                        planEntity.planDogs.size()))
+                .from(planEntity)
+                .where(
+                        planEntity.memberId.eq(planSearchCondition.getMemberId()),
+                        dateThan(planSearchCondition.getDateFilter())
+                )
+                .orderBy(
+                        orderBySortOrder(planSearchCondition.getSortOrder())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(planEntity.count())
+                .from(planEntity)
+                .where(
+                        planEntity.memberId.eq(planSearchCondition.getMemberId()),
+                        dateThan(planSearchCondition.getDateFilter())
+                )
+                .fetchOne();
+
+        return new PageImpl<>(plans, pageable, Optional.ofNullable(total).orElse(0L));
+    }
+
+    private static OrderSpecifier<Long> orderBySortOrder(SortOrder sortOrder) {
+        if (sortOrder.isDesc()) {
+            return planEntity.id.desc();
+        }
+        return planEntity.id.asc();
+    }
+
+    private BooleanExpression dateThan(DateFilter dateFilter) {
+        LocalDate today = LocalDate.now();
+
+        if (dateFilter.isBefore()) {
+            return planEntity.date.lt(today);
+        }
+        if (dateFilter.isAfter()) {
+            return planEntity.date.goe(today);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    -

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - 일정 리스트 조회 API
    - 페이징 공통 응답
    - command 패키지
    - @RequestObject 사용하면 요청파라미터를 여러개 받을때, 하나의 객체에서 관리할 수 있었음.

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 페이징 공통 응답을 만든 이유? 
    1) org.springframework.data.domain.* 에 페이징 관련 클래스들은 Spring Data 의존성을 추가해야 사용가능하므로 service와 controller 계층에 있는게 맞을까? 라는 생각이 들었음.
    2) swagger에 사용하지 않는 필드까지 생겨서 나도 헷갈릴 거 같아서 swagger 주석을 더함.

    - application과 infrastructure 하위의 command 패키지를 만든 이유?
    1) querydsl의 annotaion을 사용하는 객체가 생김.
    2) 아래 그림의 구조를 만들어봤음. 
<img width="818" alt="스크린샷 2024-12-05 02 12 24" src="https://github.com/user-attachments/assets/68555aa1-ea09-4547-8a33-f6f908d0af33">


> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
