### PR TITLE
refactor:  @Query 삭제 -> BoolQuery, ElasticsearchTemplate을 활용한 ComplexQuery 처리

### DIFF
--- a/src/main/java/com/ureca/gate/global/util/city/CityMapper.java
+++ b/src/main/java/com/ureca/gate/global/util/city/CityMapper.java
@@ -1,0 +1,32 @@
+package com.ureca.gate.global.util.city;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CityMapper {
+    private static final Map<Long, String> cityMap = new HashMap<>();
+
+    static {
+        cityMap.put(1L, "경기도");
+        cityMap.put(2L, "서울특별시");
+        cityMap.put(3L, "인천광역시");
+        cityMap.put(4L, "경상북도");
+        cityMap.put(5L, "대구광역시");
+        cityMap.put(6L, "전라북도");
+        cityMap.put(7L, "경상남도");
+        cityMap.put(8L, "전라남도");
+        cityMap.put(9L, "부산광역시");
+        cityMap.put(10L, "광주광역시");
+        cityMap.put(11L, "강원도");
+        cityMap.put(12L, "대전광역시");
+        cityMap.put(13L, "충청북도");
+        cityMap.put(14L, "제주특별자치도");
+        cityMap.put(15L, "충청남도");
+        cityMap.put(16L, "울산광역시");
+        cityMap.put(17L, "세종");
+    }
+
+    public static String getCityName(Long cityId) {
+        return cityMap.getOrDefault(cityId, "Unknown");
+    }
+}

--- a/src/main/java/com/ureca/gate/place/application/PlaceForPlanServiceImpl.java
+++ b/src/main/java/com/ureca/gate/place/application/PlaceForPlanServiceImpl.java
@@ -20,16 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlaceForPlanServiceImpl implements PlaceForPlanService {
     private final PlaceElasticRepository placeElasticRepository;
     @Override
-    public SliceResponse<PlaceForPlanResponse> getPlacesForPlan(String query, String city, String category, int page) {
+    public SliceResponse<PlaceForPlanResponse>  getPlacesForPlan(String query, String city, String category, int page) {
 
         log.info("Executing search for query: {}, city: {}, category: {}", query, city, category);
 
         Pageable pageable = PageRequest.of(page, 20,
                 Sort.by(Sort.Order.desc("_score"), Sort.Order.desc("starAvg"))); // _score(정확도)와 starAvg(평점) 기준 정렬
 
-        CustomSlice<SearchPlace> customSlice = (query != null && !query.isEmpty())
-                ? placeElasticRepository.findByQueryAndCategoryAndCity(query, category, city, pageable)
-                : placeElasticRepository.findByCategoryAndCity(category, city, pageable);
+        CustomSlice<SearchPlace> customSlice =placeElasticRepository.findByQueryAndCategoryAndCity(query, city, category,pageable);
 
         return SliceResponse.from(customSlice, PlaceForPlanResponse::from);
 

--- a/src/main/java/com/ureca/gate/place/application/outputport/PlaceElasticRepository.java
+++ b/src/main/java/com/ureca/gate/place/application/outputport/PlaceElasticRepository.java
@@ -16,8 +16,6 @@ public interface PlaceElasticRepository{
             Pageable pageable
     );
 
-    CustomSlice<SearchPlace> findByCategoryAndCity(String category, String city, Pageable pageable);
-
     Optional<SearchPlace> findById(Long placeElasticId);
 
     SearchPlace update(SearchPlace SearchPlace);

--- a/src/main/java/com/ureca/gate/place/controller/PlaceController.java
+++ b/src/main/java/com/ureca/gate/place/controller/PlaceController.java
@@ -3,6 +3,7 @@ package com.ureca.gate.place.controller;
 import com.ureca.gate.dog.domain.enumeration.Size;
 import com.ureca.gate.global.dto.response.SliceResponse;
 import com.ureca.gate.global.dto.response.SuccessResponse;
+import com.ureca.gate.global.util.city.CityMapper;
 import com.ureca.gate.place.controller.inputport.*;
 import com.ureca.gate.place.controller.response.*;
 import com.ureca.gate.place.domain.PopularPlace;
@@ -73,15 +74,18 @@ public class PlaceController {
      */
     @Operation(summary = "일정(장소선택) 시설 리스트 조회 API", description = "일정(장소선택) 시설 리스트 조회 API - hasNext =true이면 다음페이자가 있다는 의미 (+더보기)")
     @GetMapping("/plan-search")
-    public SuccessResponse<SliceResponse<PlaceForPlanResponse>> getPlacesForPlan(@RequestParam(value = "query", required = false) String query,
-                                                                                 @Parameter(description = "지역", example = "부산")
-                                                                                 @RequestParam("city") String city,
+    public SuccessResponse<SliceResponse<PlaceForPlanResponse> > getPlacesForPlan(@RequestParam(value = "query", required = false) String query,
+                                                                                 @Parameter(description = "지역", example = "1")
+                                                                                 @RequestParam("cityId") Long cityId,
                                                                                  @Parameter(description = "카테고리. 가능한 값: [식당,카페,숙소,문화시설,여행지]",
                                                                                          example = "식당")
-                                                                                 @RequestParam("category") String category,
+                                                                                 @RequestParam(value = "category", required = false) String category,
                                                                                  @Parameter(description = "페이지 순서 0부터 시작 ")
                                                                                  @RequestParam(value = "page", defaultValue = "0") int page){
-        SliceResponse<PlaceForPlanResponse> response = placeForPlanService.getPlacesForPlan(query,city, category, page);
+
+        // cityId를 cityName으로 변환
+        String city = CityMapper.getCityName(cityId);
+        SliceResponse<PlaceForPlanResponse>  response = placeForPlanService.getPlacesForPlan(query,city, category, page);
         return SuccessResponse.success(response);
     }
 

--- a/src/main/java/com/ureca/gate/place/infrastructure/elasticsearchadapter/BoolQueryBuilder.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/elasticsearchadapter/BoolQueryBuilder.java
@@ -1,0 +1,51 @@
+package com.ureca.gate.place.infrastructure.elasticsearchadapter;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class BoolQueryBuilder {
+    public Query searchPlacesQuery(String query, String category, String city) {
+        // "should" 조건을 추가할 리스트 생성
+        List<Query> shouldQueries = new ArrayList<>();
+
+        // query가 null이 아니고 비어있지 않으면 "should" 조건(nameKeyword, name)에 해당하는 쿼리들 추가
+        if (query != null && !query.isEmpty()) {
+            shouldQueries.add(new TermQuery.Builder().field("nameKeyword").value(query).boost(2F).build()._toQuery());
+            shouldQueries.add(new MatchQuery.Builder().field("name").query(query).operator(Operator.Or).boost(1F).fuzziness("AUTO").build()._toQuery());
+        }
+        // "filter" 조건(category, city)에 해당하는 Term 쿼리들 추가
+        List<Query> filterQueries = new ArrayList<>();
+
+        // category가 null이 아니면 필터 조건에 추가
+        if (category != null) {
+            filterQueries.add(new TermQuery.Builder().field("category").value(category).build()._toQuery());
+        }
+
+        // city가 null이 아니면 필터 조건에 추가
+        if (city != null) {
+            filterQueries.add(new TermQuery.Builder().field("city").value(city).build()._toQuery());
+        }
+
+        // BoolQuery 생성
+        BoolQuery.Builder boolQueryBuilder = new BoolQuery.Builder();
+
+        // query가 있을 경우에만 "should" 조건을 추가
+        if (!shouldQueries.isEmpty()) {
+            boolQueryBuilder.should(shouldQueries);
+        }
+
+        // "filter" 조건 설정 (category나 city가 null이 아니면 필터 조건을 설정)
+        if (!filterQueries.isEmpty()) {
+            boolQueryBuilder.filter(filterQueries);
+        }
+
+        return boolQueryBuilder.build()._toQuery();
+    }
+}
+
+
+

--- a/src/main/java/com/ureca/gate/place/infrastructure/elasticsearchadapter/PlaceElasticRepositoryImpl.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/elasticsearchadapter/PlaceElasticRepositoryImpl.java
@@ -1,33 +1,54 @@
 package com.ureca.gate.place.infrastructure.elasticsearchadapter;
 
 
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.elasticsearch.client.elc.*;
 import com.ureca.gate.global.domain.CustomSlice;
 import com.ureca.gate.place.application.outputport.PlaceElasticRepository;
 import com.ureca.gate.place.domain.SearchPlace;
 import com.ureca.gate.place.infrastructure.elasticsearchadapter.Document.PlaceElastic;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
 public class PlaceElasticRepositoryImpl implements PlaceElasticRepository {
     private final PlaceElasticSearchRepository placeElasticSearchRepository;
+    private final BoolQueryBuilder boolQueryBuilder;
+    private final ElasticsearchTemplate elasticsearchTemplate;
+
 
     @Override
     public CustomSlice<SearchPlace> findByQueryAndCategoryAndCity(String query, String city, String category, Pageable pageable) {
-        Page<PlaceElastic> placeElasticPage = placeElasticSearchRepository.findByQueryAndCategoryAndCity(query,city,category,pageable);
-        CustomSlice<PlaceElastic> placeElasticCustomSlice = CustomSlice.from(placeElasticPage);
-        return CustomSlice.convert(placeElasticCustomSlice,PlaceElastic::toModel);
-    }
 
-    @Override
-    public CustomSlice<SearchPlace> findByCategoryAndCity(String category, String city, Pageable pageable) {
-        Page<PlaceElastic> placeElasticPage =  placeElasticSearchRepository.findByCategoryAndCity(category,city,pageable);
-        CustomSlice<PlaceElastic> placeElasticCustomSlice = CustomSlice.from(placeElasticPage);
+        Query elasticSearchQuery = boolQueryBuilder.searchPlacesQuery(query, category, city);
+        System.out.println("Generated Query: " + elasticSearchQuery.toString());  // 쿼리 확인
+
+        NativeQuery searchQuery = new NativeQuery(elasticSearchQuery);
+        searchQuery.setPageable(pageable);
+        SearchHits<PlaceElastic> searchHits = elasticsearchTemplate.search(searchQuery, PlaceElastic.class);
+
+        List<PlaceElastic> placeElastics = searchHits.getSearchHits().stream()
+                .map(SearchHit::getContent)  // SearchHit에서 content (PlaceElastic 객체) 추출
+                .collect(Collectors.toList());
+
+        // hasNext를 확인하여 Slice 객체 생성
+        boolean hasNext = searchHits.getTotalHits() > (long) (pageable.getPageNumber() + 1) * pageable.getPageSize();
+
+        // Slice 객체 생성 (hasNext를 통해 다음 페이지 여부 확인)
+        Slice<PlaceElastic> slice = new SliceImpl<>(placeElastics, pageable, hasNext);
+        CustomSlice<PlaceElastic> placeElasticCustomSlice = CustomSlice.from(slice);
+
         return CustomSlice.convert(placeElasticCustomSlice,PlaceElastic::toModel);
     }
 

--- a/src/main/java/com/ureca/gate/place/infrastructure/elasticsearchadapter/PlaceElasticSearchRepository.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/elasticsearchadapter/PlaceElasticSearchRepository.java
@@ -2,27 +2,9 @@ package com.ureca.gate.place.infrastructure.elasticsearchadapter;
 
 import com.ureca.gate.place.infrastructure.elasticsearchadapter.Document.PlaceElastic;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface PlaceElasticSearchRepository extends ElasticsearchRepository<PlaceElastic, Long> {
-
-    @Query("{\"bool\": {\"should\": [" +
-            "{\"term\": {\"nameKeyword\": {\"value\": \"?0\", \"boost\": 2.0}}}, " +
-            "{\"match\": {\"name\": {\"query\": \"?0\", \"operator\": \"or\", \"boost\": 1.0, \"fuzziness\": \"AUTO\"}}}" +
-            "], \"filter\": [" +
-            "{\"term\": {\"category\": \"?1\"}}, " +
-            "{\"term\": {\"city\": \"?2\"}}" +
-            "]}}}")
-    Page<PlaceElastic> findByQueryAndCategoryAndCity(String query, String category, String city, Pageable pageable);
-
-    @Query("{\"bool\": {\"filter\": [" +
-            "{\"term\": {\"category\": \"?0\"}}, " +
-            "{\"term\": {\"city\": \"?1\"}}" +
-            "]}}")
-    Page<PlaceElastic> findByCategoryAndCity(String category, String city, Pageable pageable);
 
 }
 


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    -  https://developerjisu.tistory.com/103#BoolQuery%2C%20ElasticsearchTemplate%EC%9D%84%20%ED%99%9C%EC%9A%A9%ED%95%9C%20ComplexQuery%20%EC%B2%98%EB%A6%AC-1

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - BoolQuery와 ElasticsearchTemplate을 사용하여 category 및 검색어가 null인 경우를 처리한 복합 쿼리 메소드 통합
    - CityMapper를 통해 cityId를 cityName으로 매핑
    - Slice 방식 처리 시 totalCount 없이 결과 반환
   => boolean hasNext = searchHits.getTotalHits() > (long) (pageable.getPageNumber() + 1) * pageable.getPageSize();


> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    -  추후 리뷰평점 평균 또한 elasticsearch 처리되도록 수정

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
