### PR TITLE
fix: [GATE-88] BoolQueryBuilders Class의 가우스 함수 거리 조절 1km -> 0.5km

### DIFF
--- a/src/main/java/com/ureca/gate/place/infrastructure/elasticsearchadapter/BoolQueryBuilders.java
+++ b/src/main/java/com/ureca/gate/place/infrastructure/elasticsearchadapter/BoolQueryBuilders.java
@@ -132,7 +132,7 @@ public class BoolQueryBuilders {
             DecayPlacement placement = new DecayPlacement.Builder()
                     .origin(JsonData.of(latitude + "," + longitude))
                     .scale(JsonData.of("10km"))
-                    .offset(JsonData.of("1km"))
+                    .offset(JsonData.of("0.5km"))
                     .decay(0.5)
                     .build();
 


### PR DESCRIPTION
> ## 📝&nbsp;&nbsp;관련 문서 레퍼런스

    -

> ## 💻&nbsp;&nbsp;어떤 것을 작업하셨나요?

    - BoolQueryBuilders Class의 가우스 함수 거리 조절 1km -> 0.5km

> ## 🙇&nbsp;&nbsp;코드 리뷰 중점사항, 예상되는 문제점

    - 

> ## 💾&nbsp;&nbsp;DB 업데이트

    - [데이터베이스 변경사항 여부] : No

> ## 📚&nbsp;&nbsp;추가된 라이브러리

    - [추가] : No
